### PR TITLE
Bumped send_file() to HTTP/1.1, added missing zero-length chunk at the end

### DIFF
--- a/http/web.py
+++ b/http/web.py
@@ -23,7 +23,7 @@ async def send_file(writer, file):
     fstat = os.stat(file)
     fsize = fstat[6]
 
-    writer.write(b'HTTP/1.0 200 OK\r\n')
+    writer.write(b'HTTP/1.1 200 OK\r\n')
     writer.write(b'Content-Type: text/html\r\n')
     writer.write('Content-Length: {}\r\n'.format(fsize).encode('utf-8'))
     writer.write(b'Accept-Ranges: none\r\n')
@@ -41,6 +41,7 @@ async def send_file(writer, file):
             writer.write(b'\r\n')
             await writer.drain()
             gc.collect()
+    writer.write(b"0\r\n")
     writer.write(b"\r\n")
     await writer.drain()
     writer.close()


### PR DESCRIPTION
I was playing around with this on my ESP32 and `curl` was giving output like this:

```
[virtualwolf@twee:~]$ curl -v http://indoor/log
*   Trying 10.0.1.102...
* TCP_NODELAY set
* Connected to indoor (10.0.1.102) port 80 (#0)
> GET /log HTTP/1.1
> Host: indoor
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.0 200 OK
< Content-Type: text/html
< Content-Length: 283
< Accept-Ranges: none
< Transfer-Encoding: chunked
<
[content of the file it's loading, snipped for brevity]
* Illegal or missing hexadecimal sequence in chunked-encoding
* Closing connection 0
curl: (56) Illegal or missing hexadecimal sequence in chunked-encoding
```
It turns out there were two issues, one is that chunked encoding is available in HTTP/1.1, not 1.0, and [it requires a final zero-length chunk to indicate there's no more](https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Encoded_data).

(As an aside, thanks so much for this repo, it's been invaluable in getting my head around how to use `uasyncio` to create a super-basic HTTP server!)